### PR TITLE
Escape values before writing to template

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+	"net/url"
 
 	"github.com/rs/zerolog"
 )
@@ -27,7 +28,8 @@ func (t Template) Substitute(with string) string {
 		if canContinue {
 			res, canContinue = jsonTemplate(s, with, t.Logger)
 		}
-		return res
+		// NOTE: AWS secrets can contain special characters so let's escape them.
+		return url.QueryEscape(res)
 	})
 	return result
 }


### PR DESCRIPTION
@harishnair96 Let me know if you think this is wrong. From my tests this works as I expect. AWS secrets can and often do contain special characters. There is an argument that could be made to say that this should be handled HGE, but here are the reasons I think it makes sense here:
- This is intended to be used with HGE so we know the downstream receiver
- The intended templates are secrets that get used in database urls which would prefer escaped values
- Doing the parsing in HGE could be quite tricky considering all the special characters that can exist in the values