### PR TITLE
Enforce 0644 for file-based secret providers

### DIFF
--- a/provider/aws_iam_auth_rds/provider.go
+++ b/provider/aws_iam_auth_rds/provider.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"os"
 	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/rds/auth"
+	providerutil "github.com/hasura/hasura-secret-refresh/provider"
 	"github.com/hasura/hasura-secret-refresh/template"
 	_ "github.com/lib/pq"
 	"github.com/rs/zerolog"
@@ -66,7 +66,7 @@ func (provider *AWSIAMAuthRDSFile) checkDSNConnectivity(dsn string) error {
 }
 
 func (provider *AWSIAMAuthRDSFile) Start() {
-	err := os.WriteFile(provider.filePath, []byte(""), 0777)
+	err := providerutil.WriteSecretFile(provider.filePath, []byte(""))
 	if err != nil {
 		provider.logger.Err(err).Msgf("error occured while writing to a file :%s", provider.filePath)
 	}
@@ -138,7 +138,7 @@ func (provider AWSIAMAuthRDSFile) getSecret() (string, error) {
 func (provider AWSIAMAuthRDSFile) writeFile(secretString string) error {
 	provider.mu.Lock()
 	defer provider.mu.Unlock()
-	err := os.WriteFile(provider.filePath, []byte(secretString), 0777)
+	err := providerutil.WriteSecretFile(provider.filePath, []byte(secretString))
 	if err != nil {
 		provider.logger.Err(err).Msgf("error occurred while writing secret to file %s", provider.filePath)
 		return err

--- a/provider/aws_secrets_manager/file_provider.go
+++ b/provider/aws_secrets_manager/file_provider.go
@@ -2,13 +2,13 @@ package aws_secrets_manager
 
 import (
 	"fmt"
-	"os"
 	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	providerutil "github.com/hasura/hasura-secret-refresh/provider"
 	"github.com/hasura/hasura-secret-refresh/template"
 	"github.com/hasura/hasura-secret-refresh/transform"
 	"github.com/rs/zerolog"
@@ -116,7 +116,7 @@ func CreateAwsSecretsManagerFile(config map[string]interface{}, logger zerolog.L
 }
 
 func (provider AwsSecretsManagerFile) Start() {
-	err := os.WriteFile(provider.filePath, []byte(""), 0777)
+	err := providerutil.WriteSecretFile(provider.filePath, []byte(""))
 	if err != nil {
 		provider.logger.Err(err).Msgf("aws_secrets_manager_file: Error occurred while writing to file %s", provider.filePath)
 	}
@@ -186,7 +186,7 @@ func (provider AwsSecretsManagerFile) getSecret() (string, error) {
 func (provider AwsSecretsManagerFile) writeFile(secretString string) error {
 	provider.mu.Lock()
 	defer provider.mu.Unlock()
-	err := os.WriteFile(provider.filePath, []byte(secretString), 0777)
+	err := providerutil.WriteSecretFile(provider.filePath, []byte(secretString))
 	if err != nil {
 		provider.logger.Err(err).Msgf("aws_secrets_manager_file: Error occurred while writing secret %s to file %s", provider.secretId, provider.filePath)
 		return err

--- a/provider/azure_key_vault/file_provider.go
+++ b/provider/azure_key_vault/file_provider.go
@@ -3,13 +3,13 @@ package azure_key_vault
 import (
 	"context"
 	"fmt"
-	"os"
 	"sync"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
+	providerutil "github.com/hasura/hasura-secret-refresh/provider"
 	"github.com/hasura/hasura-secret-refresh/template"
 	"github.com/hasura/hasura-secret-refresh/transform"
 	"github.com/rs/zerolog"
@@ -151,7 +151,7 @@ func CreateAzureKeyVaultFile(config map[string]interface{}, logger zerolog.Logge
 }
 
 func (provider AzureKeyVaultFile) Start() {
-	err := os.WriteFile(provider.filePath, []byte(""), 0600)
+	err := providerutil.WriteSecretFile(provider.filePath, []byte(""))
 	if err != nil {
 		provider.logger.Err(err).Msgf("azure_key_vault_file: Error occurred while writing to file %s", provider.filePath)
 	}
@@ -225,7 +225,7 @@ func (provider AzureKeyVaultFile) getSecret() (string, error) {
 func (provider AzureKeyVaultFile) writeFile(secretString string) error {
 	provider.mu.Lock()
 	defer provider.mu.Unlock()
-	err := os.WriteFile(provider.filePath, []byte(secretString), 0600)
+	err := providerutil.WriteSecretFile(provider.filePath, []byte(secretString))
 	if err != nil {
 		provider.logger.Err(err).Msgf("azure_key_vault_file: Error occurred while writing secret %s to file %s", provider.secretName, provider.filePath)
 		return err

--- a/provider/file.go
+++ b/provider/file.go
@@ -1,0 +1,14 @@
+package provider
+
+import "os"
+
+const SecretFileMode os.FileMode = 0o644
+
+// WriteSecretFile writes secret data and enforces a consistent mode even when
+// the target file already exists with a more restrictive permission set.
+func WriteSecretFile(path string, content []byte) error {
+	if err := os.WriteFile(path, content, SecretFileMode); err != nil {
+		return err
+	}
+	return os.Chmod(path, SecretFileMode)
+}

--- a/provider/file_test.go
+++ b/provider/file_test.go
@@ -1,0 +1,53 @@
+package provider
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteSecretFileCreatesExpectedMode(t *testing.T) {
+	t.Parallel()
+
+	filePath := filepath.Join(t.TempDir(), "secret.json")
+
+	if err := WriteSecretFile(filePath, []byte(`{"token":"value"}`)); err != nil {
+		t.Fatalf("WriteSecretFile() error = %v", err)
+	}
+
+	info, err := os.Stat(filePath)
+	if err != nil {
+		t.Fatalf("os.Stat() error = %v", err)
+	}
+
+	if got := info.Mode().Perm(); got != SecretFileMode {
+		t.Fatalf("file mode = %#o, want %#o", got, SecretFileMode)
+	}
+}
+
+func TestWriteSecretFileResetsExistingMode(t *testing.T) {
+	t.Parallel()
+
+	filePath := filepath.Join(t.TempDir(), "secret.json")
+
+	if err := os.WriteFile(filePath, []byte("stale"), 0o600); err != nil {
+		t.Fatalf("os.WriteFile() setup error = %v", err)
+	}
+
+	if err := os.Chmod(filePath, 0o600); err != nil {
+		t.Fatalf("os.Chmod() setup error = %v", err)
+	}
+
+	if err := WriteSecretFile(filePath, []byte(`{"token":"updated"}`)); err != nil {
+		t.Fatalf("WriteSecretFile() error = %v", err)
+	}
+
+	info, err := os.Stat(filePath)
+	if err != nil {
+		t.Fatalf("os.Stat() error = %v", err)
+	}
+
+	if got := info.Mode().Perm(); got != SecretFileMode {
+		t.Fatalf("file mode = %#o, want %#o", got, SecretFileMode)
+	}
+}


### PR DESCRIPTION
## Summary
- centralize file writes behind a helper that enforces `0644`
- use that helper from the AWS Secrets Manager, Azure Key Vault, and AWS IAM auth file providers
- add regression tests covering both new-file creation and overwriting an existing `0600` file

## Why
In `initcontainer` mode the proxy calls `Refresh()` directly, so the provider-specific `writeFile()` mode is what lands on the shared `emptyDir`. Before this change, `file_azure_key_vault` wrote files with `0600` while `file_aws_secrets_manager` wrote them with `0777`, which produced inconsistent readability across providers.

Using `os.WriteFile(..., 0644)` alone is not sufficient when the file already exists with a more restrictive mode, so the helper also calls `os.Chmod(..., 0644)` after writing.

## Testing
- `go test -vet=off ./provider -run TestWriteSecretFile`
- `go test -vet=off ./provider/aws_secrets_manager -run ^`
- `go test -vet=off ./provider/azure_key_vault -run ^`
- `go test -vet=off ./provider/aws_iam_auth_rds -run ^`
