### PR TITLE
Normalize file-backed secret permissions to 0644

### DIFF
--- a/e2e-test/AZURE_E2E_TEST_GUIDE.md
+++ b/e2e-test/AZURE_E2E_TEST_GUIDE.md
@@ -25,7 +25,7 @@ VALIDATION REQUIREMENTS:
 - Documentation validation (README.md, examples, test plans)
 - Error handling validation (proper error types and wrapping)
 - Logging validation (Info, Error, Debug levels)
-- Security validation (no secrets in logs, file permissions 0600)
+- Security validation (no secrets in logs, file permissions 0644)
 
 AZURE SETUP REQUIREMENTS:
 - Check Azure CLI login and subscription
@@ -44,7 +44,7 @@ INTEGRATION TEST REQUIREMENTS:
   * X-Hasura-Secret-Provider: provider name from config
   * X-Hasura-Secret-Header: template like "Authorization: Bearer ##secret##"
   * X-Hasura-Secret-Name: secret name in Azure Key Vault
-- File provider testing with permission checks (0600)
+- File provider testing with permission checks (0644)
 - Template substitution validation for JSON secrets
 - Refresh endpoint testing
 - Performance testing with cache timing (3 requests to measure cache effectiveness)
@@ -57,7 +57,7 @@ REQUIREMENTS:
 - Use current configuration format from config.yaml and examples/
 - CRITICAL: Use cross-platform commands (avoid 'timeout' - use sleep + kill instead)
 - Test HTTP providers (Actions/Remote Schemas) and File providers (Data Sources)
-- Verify template substitution, caching, file permissions (0600), no secret leaks
+- Verify template substitution, caching, file permissions (0644), no secret leaks
 - Include proper error handling and cleanup procedures
 - Support both Service Principal and Managed Identity authentication
 - All generated files should be self-contained in the test directory
@@ -78,7 +78,7 @@ Verify these work correctly:
 - [ ] Documentation validation (README.md, examples, test plans)
 - [ ] Error handling validation (proper error types and wrapping)
 - [ ] Logging validation (Info, Error, Debug levels implemented)
-- [ ] Security validation (no secrets in logs, file permissions 0600)
+- [ ] Security validation (no secrets in logs, file permissions 0644)
 
 ### ✅ Azure Integration (comprehensive setup)
 - [ ] Azure CLI login and subscription verification
@@ -97,7 +97,7 @@ Verify these work correctly:
 - [ ] Caching functionality validation
 
 ### ✅ File Provider Testing (file_azure_key_vault)
-- [ ] Secret files created with correct permissions (0600)
+- [ ] Secret files created with correct permissions (0644)
 - [ ] Template substitution for JSON secrets (MongoDB connection string)
 - [ ] Automatic refresh functionality
 - [ ] Manual refresh via endpoint
@@ -105,7 +105,7 @@ Verify these work correctly:
 
 ### ✅ Performance & Security
 - [ ] Cache timing tests (first request slow, subsequent fast)
-- [ ] File permission security (0600 enforcement)
+- [ ] File permission security (0644 enforcement)
 - [ ] Log security (no secrets visible in logs)
 - [ ] Proper error handling and logging
 - [ ] Memory usage and performance acceptable

--- a/provider/aws_iam_auth_rds/provider.go
+++ b/provider/aws_iam_auth_rds/provider.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"os"
 	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/rds/auth"
+	sharedprovider "github.com/hasura/hasura-secret-refresh/provider"
 	"github.com/hasura/hasura-secret-refresh/template"
 	_ "github.com/lib/pq"
 	"github.com/rs/zerolog"
@@ -66,7 +66,7 @@ func (provider *AWSIAMAuthRDSFile) checkDSNConnectivity(dsn string) error {
 }
 
 func (provider *AWSIAMAuthRDSFile) Start() {
-	err := os.WriteFile(provider.filePath, []byte(""), 0777)
+	err := sharedprovider.WriteSecretFile(provider.filePath, []byte(""))
 	if err != nil {
 		provider.logger.Err(err).Msgf("error occured while writing to a file :%s", provider.filePath)
 	}
@@ -138,7 +138,7 @@ func (provider AWSIAMAuthRDSFile) getSecret() (string, error) {
 func (provider AWSIAMAuthRDSFile) writeFile(secretString string) error {
 	provider.mu.Lock()
 	defer provider.mu.Unlock()
-	err := os.WriteFile(provider.filePath, []byte(secretString), 0777)
+	err := sharedprovider.WriteSecretFile(provider.filePath, []byte(secretString))
 	if err != nil {
 		provider.logger.Err(err).Msgf("error occurred while writing secret to file %s", provider.filePath)
 		return err

--- a/provider/aws_secrets_manager/file_provider.go
+++ b/provider/aws_secrets_manager/file_provider.go
@@ -2,13 +2,13 @@ package aws_secrets_manager
 
 import (
 	"fmt"
-	"os"
 	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	sharedprovider "github.com/hasura/hasura-secret-refresh/provider"
 	"github.com/hasura/hasura-secret-refresh/template"
 	"github.com/hasura/hasura-secret-refresh/transform"
 	"github.com/rs/zerolog"
@@ -116,7 +116,7 @@ func CreateAwsSecretsManagerFile(config map[string]interface{}, logger zerolog.L
 }
 
 func (provider AwsSecretsManagerFile) Start() {
-	err := os.WriteFile(provider.filePath, []byte(""), 0777)
+	err := sharedprovider.WriteSecretFile(provider.filePath, []byte(""))
 	if err != nil {
 		provider.logger.Err(err).Msgf("aws_secrets_manager_file: Error occurred while writing to file %s", provider.filePath)
 	}
@@ -186,7 +186,7 @@ func (provider AwsSecretsManagerFile) getSecret() (string, error) {
 func (provider AwsSecretsManagerFile) writeFile(secretString string) error {
 	provider.mu.Lock()
 	defer provider.mu.Unlock()
-	err := os.WriteFile(provider.filePath, []byte(secretString), 0777)
+	err := sharedprovider.WriteSecretFile(provider.filePath, []byte(secretString))
 	if err != nil {
 		provider.logger.Err(err).Msgf("aws_secrets_manager_file: Error occurred while writing secret %s to file %s", provider.secretId, provider.filePath)
 		return err

--- a/provider/aws_secrets_manager/file_provider_test.go
+++ b/provider/aws_secrets_manager/file_provider_test.go
@@ -2,11 +2,13 @@ package aws_secrets_manager
 
 import (
 	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	sharedprovider "github.com/hasura/hasura-secret-refresh/provider"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -381,4 +383,25 @@ func TestAwsSecretsManagerFile_FileName(t *testing.T) {
 	provider, err := CreateAwsSecretsManagerFile(config, logger)
 	assert.NoError(t, err)
 	assert.Equal(t, "/tmp/test-secret", provider.FileName())
+}
+
+func TestAwsSecretsManagerFile_writeFileNormalizesPermissions(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "secret.json")
+	err := os.WriteFile(filePath, []byte("old"), 0o600)
+	assert.NoError(t, err)
+	assert.NoError(t, os.Chmod(filePath, 0o600))
+
+	provider := AwsSecretsManagerFile{
+		filePath: filePath,
+		secretId: "test-secret",
+		logger:   zerolog.Nop(),
+		mu:       &sync.Mutex{},
+	}
+
+	err = provider.writeFile("new-secret")
+	assert.NoError(t, err)
+
+	info, err := os.Stat(filePath)
+	assert.NoError(t, err)
+	assert.Equal(t, sharedprovider.SecretFileMode, info.Mode().Perm())
 }

--- a/provider/azure_key_vault/file_provider.go
+++ b/provider/azure_key_vault/file_provider.go
@@ -3,13 +3,13 @@ package azure_key_vault
 import (
 	"context"
 	"fmt"
-	"os"
 	"sync"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
+	sharedprovider "github.com/hasura/hasura-secret-refresh/provider"
 	"github.com/hasura/hasura-secret-refresh/template"
 	"github.com/hasura/hasura-secret-refresh/transform"
 	"github.com/rs/zerolog"
@@ -151,7 +151,7 @@ func CreateAzureKeyVaultFile(config map[string]interface{}, logger zerolog.Logge
 }
 
 func (provider AzureKeyVaultFile) Start() {
-	err := os.WriteFile(provider.filePath, []byte(""), 0600)
+	err := sharedprovider.WriteSecretFile(provider.filePath, []byte(""))
 	if err != nil {
 		provider.logger.Err(err).Msgf("azure_key_vault_file: Error occurred while writing to file %s", provider.filePath)
 	}
@@ -225,7 +225,7 @@ func (provider AzureKeyVaultFile) getSecret() (string, error) {
 func (provider AzureKeyVaultFile) writeFile(secretString string) error {
 	provider.mu.Lock()
 	defer provider.mu.Unlock()
-	err := os.WriteFile(provider.filePath, []byte(secretString), 0600)
+	err := sharedprovider.WriteSecretFile(provider.filePath, []byte(secretString))
 	if err != nil {
 		provider.logger.Err(err).Msgf("azure_key_vault_file: Error occurred while writing secret %s to file %s", provider.secretName, provider.filePath)
 		return err

--- a/provider/azure_key_vault/file_provider_test.go
+++ b/provider/azure_key_vault/file_provider_test.go
@@ -1,8 +1,12 @@
 package azure_key_vault
 
 import (
+	"os"
+	"path/filepath"
+	"sync"
 	"testing"
 
+	sharedprovider "github.com/hasura/hasura-secret-refresh/provider"
 	"github.com/rs/zerolog"
 )
 
@@ -233,5 +237,37 @@ func TestAzureKeyVaultFile_FileName(t *testing.T) {
 	fileName := provider.FileName()
 	if fileName != "/tmp/test-secret" {
 		t.Errorf("Expected file name '/tmp/test-secret', got '%s'", fileName)
+	}
+}
+
+func TestAzureKeyVaultFile_writeFileNormalizesPermissions(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "secret.json")
+	err := os.WriteFile(filePath, []byte("old"), 0o600)
+	if err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+
+	if err := os.Chmod(filePath, 0o600); err != nil {
+		t.Fatalf("Chmod returned error: %v", err)
+	}
+
+	provider := AzureKeyVaultFile{
+		filePath:   filePath,
+		secretName: "test-secret",
+		logger:     zerolog.Nop(),
+		mu:         &sync.Mutex{},
+	}
+
+	if err := provider.writeFile("new-secret"); err != nil {
+		t.Fatalf("writeFile returned error: %v", err)
+	}
+
+	info, err := os.Stat(filePath)
+	if err != nil {
+		t.Fatalf("Stat returned error: %v", err)
+	}
+
+	if got := info.Mode().Perm(); got != sharedprovider.SecretFileMode {
+		t.Fatalf("expected mode %04o, got %04o", sharedprovider.SecretFileMode, got)
 	}
 }

--- a/provider/file_permissions.go
+++ b/provider/file_permissions.go
@@ -1,0 +1,16 @@
+package provider
+
+import "os"
+
+const SecretFileMode os.FileMode = 0o644
+
+// WriteSecretFile normalizes the file mode after every write so file-backed
+// secrets stay readable by sibling containers even when the file already
+// exists or the process umask is restrictive.
+func WriteSecretFile(path string, contents []byte) error {
+	if err := os.WriteFile(path, contents, SecretFileMode); err != nil {
+		return err
+	}
+
+	return os.Chmod(path, SecretFileMode)
+}

--- a/provider/file_permissions_test.go
+++ b/provider/file_permissions_test.go
@@ -1,0 +1,49 @@
+package provider
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteSecretFileCreatesFileWithExpectedMode(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "secret.json")
+
+	if err := WriteSecretFile(filePath, []byte(`{"token":"value"}`)); err != nil {
+		t.Fatalf("WriteSecretFile returned error: %v", err)
+	}
+
+	info, err := os.Stat(filePath)
+	if err != nil {
+		t.Fatalf("Stat returned error: %v", err)
+	}
+
+	if got := info.Mode().Perm(); got != SecretFileMode {
+		t.Fatalf("expected mode %04o, got %04o", SecretFileMode, got)
+	}
+}
+
+func TestWriteSecretFileNormalizesExistingMode(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "secret.json")
+
+	if err := os.WriteFile(filePath, []byte("old"), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+
+	if err := os.Chmod(filePath, 0o600); err != nil {
+		t.Fatalf("Chmod returned error: %v", err)
+	}
+
+	if err := WriteSecretFile(filePath, []byte("new")); err != nil {
+		t.Fatalf("WriteSecretFile returned error: %v", err)
+	}
+
+	info, err := os.Stat(filePath)
+	if err != nil {
+		t.Fatalf("Stat returned error: %v", err)
+	}
+
+	if got := info.Mode().Perm(); got != SecretFileMode {
+		t.Fatalf("expected mode %04o, got %04o", SecretFileMode, got)
+	}
+}


### PR DESCRIPTION
## Summary
- normalize file-backed secret permissions to `0644` via a shared helper
- use the helper from the AWS Secrets Manager, Azure Key Vault, and AWS IAM auth RDS file providers
- add focused tests proving provider writes normalize an existing `0600` file to `0644`

## Why
Azure Key Vault was writing secret files with `0600`, which left them readable only by the init-container user. AWS Secrets Manager was more permissive because it used `0777`, but that depended on `umask` and still did not guarantee `0644`.

This change makes the behavior deterministic across providers by explicitly `chmod`-ing the file to `0644` after each write.

## Validation
- `go test ./provider`
- `go test ./provider/aws_secrets_manager`
- `go test ./provider/azure_key_vault -run TestAzureKeyVaultFile_writeFileNormalizesPermissions`
- `go test ./provider/aws_iam_auth_rds`

## Notes
`go test ./...` is already failing on `main` for unrelated reasons:
- `provider/azure_key_vault` has pre-existing failing tests unrelated to file mode handling
- `server` fails `go test`/vet due to non-constant `Msgf` format strings
