### PR TITLE
ci: re-enable trivy vulnerability scanning with SHA-pinned action

### DIFF
--- a/.github/workflows/build-and-scan-services.yaml
+++ b/.github/workflows/build-and-scan-services.yaml
@@ -58,7 +58,7 @@ jobs:
           echo "DOCKER_IMG=${DOCKER_IMG}" >> $GITHUB_ENV
 
       - name: Run Trivy vulnerability scanner (json output)
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ env.DOCKER_IMG }}
           format: json
@@ -81,7 +81,7 @@ jobs:
             team=platform
 
       - name: Fail build on High/Critical Vulnerabilities
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           skip-setup-trivy: true # setup was already done by the previous call to this action above
           image-ref: ${{ env.DOCKER_IMG }}

--- a/.github/workflows/build-and-scan-services.yaml
+++ b/.github/workflows/build-and-scan-services.yaml
@@ -66,14 +66,15 @@ jobs:
           scanners: vuln
 
       - name: Upload Trivy scan results to PromptQL Security Agent
+        if: github.event_name != 'pull_request'
         uses: hasura/security-agent-tools/upload-file@v1
         with:
           file_path: trivy-results.json
           security_agent_api_key: ${{ secrets.SECURITY_AGENT_API_KEY }}
           tags: |
             service=${{ matrix.service.name }}
-            source_code_path=${{ matrix.service.source_code_path }}
-            docker_file_path=${{ matrix.service.docker_file_path }}
+            source_code_path=${{ matrix.service.dockerContextPath }}
+            docker_file_path=${{ matrix.service.dockerFilePath }}
             scanner=trivy
             image_name=${{ env.DOCKER_IMG }}
             product_domain=${{ matrix.service.domain }}

--- a/.github/workflows/build-and-scan-services.yaml
+++ b/.github/workflows/build-and-scan-services.yaml
@@ -58,7 +58,7 @@ jobs:
           echo "DOCKER_IMG=${DOCKER_IMG}" >> $GITHUB_ENV
 
       - name: Run Trivy vulnerability scanner (json output)
-        uses: aquasecurity/trivy-action@854c61d34a550a9fcbab3bc59e55b868c15d1962
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
         with:
           image-ref: ${{ env.DOCKER_IMG }}
           format: json
@@ -80,7 +80,7 @@ jobs:
             team=platform
 
       - name: Fail build on High/Critical Vulnerabilities
-        uses: aquasecurity/trivy-action@854c61d34a550a9fcbab3bc59e55b868c15d1962
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
         with:
           skip-setup-trivy: true # setup was already done by the previous call to this action above
           image-ref: ${{ env.DOCKER_IMG }}

--- a/.github/workflows/build-and-scan-services.yaml
+++ b/.github/workflows/build-and-scan-services.yaml
@@ -57,35 +57,35 @@ jobs:
           echo "DOCKER_IMG = $DOCKER_IMG"
           echo "DOCKER_IMG=${DOCKER_IMG}" >> $GITHUB_ENV
 
-#       - name: Run Trivy vulnerability scanner (json output)
-#         uses: aquasecurity/trivy-action@v0.35.0
-#         with:
-#           image-ref: ${{ env.DOCKER_IMG }}
-#           format: json
-#           output: trivy-results.json
-#           scanners: vuln
-# 
-#       - name: Upload Trivy scan results to PromptQL Security Agent
-#         uses: hasura/security-agent-tools/upload-file@v1
-#         with:
-#           file_path: trivy-results.json
-#           security_agent_api_key: ${{ secrets.SECURITY_AGENT_API_KEY }}
-#           tags: |
-#             service=${{ matrix.service.name }}
-#             source_code_path=${{ matrix.service.source_code_path }}
-#             docker_file_path=${{ matrix.service.docker_file_path }}
-#             scanner=trivy
-#             image_name=${{ env.DOCKER_IMG }}
-#             product_domain=${{ matrix.service.domain }}
-#             team=platform
-# 
-#       - name: Fail build on High/Critical Vulnerabilities
-#         uses: aquasecurity/trivy-action@v0.35.0
-#         with:
-#           skip-setup-trivy: true # setup was already done by the previous call to this action above
-#           image-ref: ${{ env.DOCKER_IMG }}
-#           format: table
-#           severity: "CRITICAL,HIGH"
-#           scanners: vuln
-#           ignore-unfixed: true
-#           exit-code: 1
+      - name: Run Trivy vulnerability scanner (json output)
+        uses: aquasecurity/trivy-action@854c61d34a550a9fcbab3bc59e55b868c15d1962
+        with:
+          image-ref: ${{ env.DOCKER_IMG }}
+          format: json
+          output: trivy-results.json
+          scanners: vuln
+
+      - name: Upload Trivy scan results to PromptQL Security Agent
+        uses: hasura/security-agent-tools/upload-file@v1
+        with:
+          file_path: trivy-results.json
+          security_agent_api_key: ${{ secrets.SECURITY_AGENT_API_KEY }}
+          tags: |
+            service=${{ matrix.service.name }}
+            source_code_path=${{ matrix.service.source_code_path }}
+            docker_file_path=${{ matrix.service.docker_file_path }}
+            scanner=trivy
+            image_name=${{ env.DOCKER_IMG }}
+            product_domain=${{ matrix.service.domain }}
+            team=platform
+
+      - name: Fail build on High/Critical Vulnerabilities
+        uses: aquasecurity/trivy-action@854c61d34a550a9fcbab3bc59e55b868c15d1962
+        with:
+          skip-setup-trivy: true # setup was already done by the previous call to this action above
+          image-ref: ${{ env.DOCKER_IMG }}
+          format: table
+          severity: "CRITICAL,HIGH"
+          scanners: vuln
+          ignore-unfixed: true
+          exit-code: 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.7-alpine AS builder
+FROM golang:1.25.9-alpine3.23 AS builder
 
 WORKDIR /app
 
@@ -12,7 +12,7 @@ COPY . .
 # Build the binary with security flags
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-extldflags "-static"' -o secrets-management-proxy
 
-FROM alpine:3.23.3
+FROM alpine:3.23.4
 
 # Install ca-certificates for HTTPS requests
 RUN apk --no-cache add ca-certificates

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/hasura/hasura-secret-refresh
 
 go 1.25.0
 
-toolchain go1.25.7
+toolchain go1.25.9
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.0


### PR DESCRIPTION
Re-enable Trivy scanning by reverting the changes from PR #30. Pin trivy-action to `ed142fd0673e97e23eac54620cfb913e5ce36c25` (v0.36.0) for security.

Co-authored-by: Poojan Savani <poojan@hasura.io>