### PR TITLE
Add file_json provider for native K8s Secrets

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	awsSm "github.com/hasura/hasura-secret-refresh/provider/aws_secrets_manager"
 	awsSmOauth "github.com/hasura/hasura-secret-refresh/provider/aws_sm_oauth"
 	azureKv "github.com/hasura/hasura-secret-refresh/provider/azure_key_vault"
+	fileJson "github.com/hasura/hasura-secret-refresh/provider/file_json"
 	hashicorpVault "github.com/hasura/hasura-secret-refresh/provider/hashicorp_vault"
 	"github.com/hasura/hasura-secret-refresh/server"
 	"github.com/rs/zerolog"
@@ -38,6 +39,7 @@ const (
 	azure_key_vault_file = "file_azure_key_vault"
 	hashicorp_vault      = "proxy_hashicorp_vault"
 	hashicorp_vault_file = "file_hashicorp_vault"
+	file_json_provider   = "file_json"
 )
 
 func main() {
@@ -238,6 +240,14 @@ func parseConfig(rawConfig map[string]interface{}, logger zerolog.Logger) (confi
 		} else if providerType == hashicorp_vault_file {
 			var fProvider_ provider.FileProvider
 			fProvider_, err = hashicorpVault.CreateHashicorpVaultFile(providerData, sublogger)
+			if err != nil {
+				sublogger.Err(err).Msgf("Error creating provider")
+				return
+			}
+			fileProviders = append(fileProviders, fProvider_)
+		} else if providerType == file_json_provider {
+			var fProvider_ provider.FileProvider
+			fProvider_, err = fileJson.CreateFileJsonProvider(providerData, sublogger)
 			if err != nil {
 				sublogger.Err(err).Msgf("Error creating provider")
 				return

--- a/provider/file_json/file_provider.go
+++ b/provider/file_json/file_provider.go
@@ -1,0 +1,177 @@
+package file_json
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	sharedprovider "github.com/hasura/hasura-secret-refresh/provider"
+	"github.com/hasura/hasura-secret-refresh/template"
+	"github.com/hasura/hasura-secret-refresh/transform"
+	"github.com/rs/zerolog"
+)
+
+type FileJsonProvider struct {
+	refreshInterval time.Duration
+	inputPath       string
+	filePath        string
+	template        string
+	secretTransform *transform.SecretTransform
+
+	logger zerolog.Logger
+	mu     *sync.Mutex
+}
+
+func CreateFileJsonProvider(config map[string]interface{}, logger zerolog.Logger) (FileJsonProvider, error) {
+	inputPathI, found := config["input_path"]
+	if !found {
+		logger.Error().Msg("file_json: Config 'input_path' not found")
+		return FileJsonProvider{}, fmt.Errorf("required configs not found")
+	}
+	inputPath, ok := inputPathI.(string)
+	if !ok {
+		logger.Error().Msg("file_json: 'input_path' must be a string")
+		return FileJsonProvider{}, fmt.Errorf("config not valid")
+	}
+
+	filePathI, found := config["path"]
+	if !found {
+		logger.Error().Msg("file_json: Config 'path' not found")
+		return FileJsonProvider{}, fmt.Errorf("required configs not found")
+	}
+	filePath, ok := filePathI.(string)
+	if !ok {
+		logger.Error().Msg("file_json: 'path' must be a string")
+		return FileJsonProvider{}, fmt.Errorf("config not valid")
+	}
+
+	refreshIntervalI, found := config["refresh"]
+	if !found {
+		logger.Error().Msg("file_json: Config 'refresh' not found")
+		return FileJsonProvider{}, fmt.Errorf("required configs not found")
+	}
+	refreshIntervalInt, ok := refreshIntervalI.(int)
+	if !ok {
+		logger.Error().Msg("file_json: 'refresh' must be an integer")
+		return FileJsonProvider{}, fmt.Errorf("config not valid")
+	}
+	refreshInterval := time.Duration(refreshIntervalInt) * time.Second
+
+	secretTemplate := ""
+	secretTemplateI, ok := config["template"]
+	if ok {
+		secretTemplate, ok = secretTemplateI.(string)
+		if !ok {
+			logger.Error().Msg("file_json: 'template' must be a string")
+			return FileJsonProvider{}, fmt.Errorf("config not valid")
+		}
+	}
+
+	secretTransform, err := transform.ParseSecretTransformFromConfig(config, logger)
+	if err != nil {
+		return FileJsonProvider{}, err
+	}
+
+	if secretTemplate != "" && secretTransform.HasTransformations() {
+		logger.Error().Msg("file_json: Only one of 'template' or 'transform' can be configured, not both")
+		return FileJsonProvider{}, fmt.Errorf("config not valid: Only one of 'template' or 'transform' can be configured, not both")
+	}
+
+	provider := FileJsonProvider{
+		refreshInterval: refreshInterval,
+		inputPath:       inputPath,
+		filePath:        filePath,
+		logger:          logger,
+		template:        secretTemplate,
+		secretTransform: secretTransform,
+		mu:              &sync.Mutex{},
+	}
+
+	logger.Info().
+		Str("refresh", refreshInterval.String()).
+		Str("input_path", inputPath).
+		Str("file_path", filePath).
+		Int("key_mappings", len(secretTransform.GetMappings())).
+		Str("transform_mode", string(secretTransform.GetMode())).
+		Msg("Creating file_json provider")
+
+	return provider, nil
+}
+
+func (provider FileJsonProvider) Start() {
+	err := sharedprovider.WriteSecretFile(provider.filePath, []byte(""))
+	if err != nil {
+		provider.logger.Err(err).Msgf("file_json: Error occurred while writing to file %s", provider.filePath)
+	}
+	for {
+		secret, err := provider.getSecret()
+		if err != nil {
+			time.Sleep(provider.refreshInterval)
+			continue
+		}
+		err = provider.writeFile(secret)
+		if err != nil {
+			time.Sleep(provider.refreshInterval)
+			continue
+		}
+		provider.logger.Info().Msgf("file_json: Successfully read secret from %s. Refreshing in %s", provider.inputPath, provider.refreshInterval)
+		time.Sleep(provider.refreshInterval)
+	}
+}
+
+func (provider FileJsonProvider) Refresh() error {
+	provider.logger.Info().Msgf("file_json: Refresh invoked for input %s", provider.inputPath)
+	secret, err := provider.getSecret()
+	if err != nil {
+		return err
+	}
+	err = provider.writeFile(secret)
+	if err != nil {
+		return err
+	}
+	provider.logger.Info().Msgf("file_json: Successfully refreshed secret from %s upon invocation", provider.inputPath)
+	return nil
+}
+
+func (provider FileJsonProvider) FileName() string {
+	return provider.filePath
+}
+
+func (provider FileJsonProvider) getSecret() (string, error) {
+	provider.logger.Info().Msgf("file_json: Reading secret from %s", provider.inputPath)
+	data, err := os.ReadFile(provider.inputPath)
+	if err != nil {
+		provider.logger.Err(err).Msgf("file_json: Error reading input file '%s'", provider.inputPath)
+		return "", err
+	}
+
+	secretString := string(data)
+
+	// Apply key mapping if configured
+	if provider.secretTransform.HasTransformations() {
+		secretString, err = provider.secretTransform.Transform(secretString)
+		if err != nil {
+			provider.logger.Err(err).Msg("file_json: Error applying secret transformation")
+			return "", err
+		}
+	}
+
+	if provider.template != "" {
+		templ := template.Template{Templ: provider.template, Logger: provider.logger}
+		secretString = templ.Substitute(secretString)
+	}
+
+	return secretString, nil
+}
+
+func (provider FileJsonProvider) writeFile(secretString string) error {
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+	err := sharedprovider.WriteSecretFile(provider.filePath, []byte(secretString))
+	if err != nil {
+		provider.logger.Err(err).Msgf("file_json: Error occurred while writing to file %s", provider.filePath)
+		return err
+	}
+	return nil
+}

--- a/provider/file_json/file_provider_test.go
+++ b/provider/file_json/file_provider_test.go
@@ -1,0 +1,243 @@
+package file_json
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateFileJsonProvider(t *testing.T) {
+	logger := zerolog.New(os.Stderr)
+
+	t.Run("valid config", func(t *testing.T) {
+		config := map[string]interface{}{
+			"type":       "file_json",
+			"input_path": "/source-secrets/secrets.json",
+			"path":       "/secrets/output.json",
+			"refresh":    60,
+		}
+
+		provider, err := CreateFileJsonProvider(config, logger)
+		require.NoError(t, err)
+		assert.Equal(t, "/source-secrets/secrets.json", provider.inputPath)
+		assert.Equal(t, "/secrets/output.json", provider.filePath)
+		assert.Equal(t, "/secrets/output.json", provider.FileName())
+	})
+
+	t.Run("missing input_path", func(t *testing.T) {
+		config := map[string]interface{}{
+			"type":    "file_json",
+			"path":    "/secrets/output.json",
+			"refresh": 60,
+		}
+
+		_, err := CreateFileJsonProvider(config, logger)
+		assert.Error(t, err)
+	})
+
+	t.Run("missing path", func(t *testing.T) {
+		config := map[string]interface{}{
+			"type":       "file_json",
+			"input_path": "/source-secrets/secrets.json",
+			"refresh":    60,
+		}
+
+		_, err := CreateFileJsonProvider(config, logger)
+		assert.Error(t, err)
+	})
+
+	t.Run("missing refresh", func(t *testing.T) {
+		config := map[string]interface{}{
+			"type":       "file_json",
+			"input_path": "/source-secrets/secrets.json",
+			"path":       "/secrets/output.json",
+		}
+
+		_, err := CreateFileJsonProvider(config, logger)
+		assert.Error(t, err)
+	})
+
+	t.Run("template and transform conflict", func(t *testing.T) {
+		config := map[string]interface{}{
+			"type":       "file_json",
+			"input_path": "/source-secrets/secrets.json",
+			"path":       "/secrets/output.json",
+			"refresh":    60,
+			"template":   "some-template",
+			"transform": map[string]interface{}{
+				"key_mappings": []interface{}{
+					map[string]interface{}{
+						"from": "a",
+						"to":   "b",
+					},
+				},
+			},
+		}
+
+		_, err := CreateFileJsonProvider(config, logger)
+		assert.Error(t, err)
+	})
+}
+
+func TestFileJsonProviderRefresh(t *testing.T) {
+	logger := zerolog.New(os.Stderr)
+
+	t.Run("reads and writes JSON file without transform", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		inputPath := filepath.Join(tmpDir, "input.json")
+		outputPath := filepath.Join(tmpDir, "output.json")
+
+		inputData := map[string]string{
+			"DB_HOST":     "localhost",
+			"DB_PASSWORD": "secret123",
+		}
+		inputBytes, _ := json.Marshal(inputData)
+		err := os.WriteFile(inputPath, inputBytes, 0644)
+		require.NoError(t, err)
+
+		config := map[string]interface{}{
+			"type":       "file_json",
+			"input_path": inputPath,
+			"path":       outputPath,
+			"refresh":    60,
+		}
+
+		provider, err := CreateFileJsonProvider(config, logger)
+		require.NoError(t, err)
+
+		err = provider.Refresh()
+		require.NoError(t, err)
+
+		output, err := os.ReadFile(outputPath)
+		require.NoError(t, err)
+
+		var outputData map[string]string
+		err = json.Unmarshal(output, &outputData)
+		require.NoError(t, err)
+		assert.Equal(t, "localhost", outputData["DB_HOST"])
+		assert.Equal(t, "secret123", outputData["DB_PASSWORD"])
+	})
+
+	t.Run("applies key mapping transform", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		inputPath := filepath.Join(tmpDir, "input.json")
+		outputPath := filepath.Join(tmpDir, "output.json")
+
+		inputData := map[string]string{
+			"HASURA_GRAPHQL_ADMIN_SECRET": "admin123",
+			"DB_PASSWORD":                 "dbpass",
+		}
+		inputBytes, _ := json.Marshal(inputData)
+		err := os.WriteFile(inputPath, inputBytes, 0644)
+		require.NoError(t, err)
+
+		config := map[string]interface{}{
+			"type":       "file_json",
+			"input_path": inputPath,
+			"path":       outputPath,
+			"refresh":    60,
+			"transform": map[string]interface{}{
+				"mode": "transformed_only",
+				"key_mappings": []interface{}{
+					map[string]interface{}{
+						"from": "HASURA_GRAPHQL_ADMIN_SECRET",
+						"to":   "ADMIN_SECRET",
+					},
+					map[string]interface{}{
+						"from": "DB_PASSWORD",
+						"to":   "POSTGRES_PASSWORD",
+					},
+				},
+			},
+		}
+
+		provider, err := CreateFileJsonProvider(config, logger)
+		require.NoError(t, err)
+
+		err = provider.Refresh()
+		require.NoError(t, err)
+
+		output, err := os.ReadFile(outputPath)
+		require.NoError(t, err)
+
+		var outputData map[string]string
+		err = json.Unmarshal(output, &outputData)
+		require.NoError(t, err)
+		assert.Equal(t, "admin123", outputData["ADMIN_SECRET"])
+		assert.Equal(t, "dbpass", outputData["POSTGRES_PASSWORD"])
+		// transformed_only mode should not include original keys
+		_, hasOriginal := outputData["HASURA_GRAPHQL_ADMIN_SECRET"]
+		assert.False(t, hasOriginal)
+	})
+
+	t.Run("keep_all mode preserves original keys", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		inputPath := filepath.Join(tmpDir, "input.json")
+		outputPath := filepath.Join(tmpDir, "output.json")
+
+		inputData := map[string]string{
+			"HASURA_GRAPHQL_ADMIN_SECRET": "admin123",
+			"DB_HOST":                     "localhost",
+		}
+		inputBytes, _ := json.Marshal(inputData)
+		err := os.WriteFile(inputPath, inputBytes, 0644)
+		require.NoError(t, err)
+
+		config := map[string]interface{}{
+			"type":       "file_json",
+			"input_path": inputPath,
+			"path":       outputPath,
+			"refresh":    60,
+			"transform": map[string]interface{}{
+				"mode": "keep_all",
+				"key_mappings": []interface{}{
+					map[string]interface{}{
+						"from": "HASURA_GRAPHQL_ADMIN_SECRET",
+						"to":   "ADMIN_SECRET",
+					},
+				},
+			},
+		}
+
+		provider, err := CreateFileJsonProvider(config, logger)
+		require.NoError(t, err)
+
+		err = provider.Refresh()
+		require.NoError(t, err)
+
+		output, err := os.ReadFile(outputPath)
+		require.NoError(t, err)
+
+		var outputData map[string]string
+		err = json.Unmarshal(output, &outputData)
+		require.NoError(t, err)
+		assert.Equal(t, "admin123", outputData["ADMIN_SECRET"])
+		assert.Equal(t, "localhost", outputData["DB_HOST"])
+		// In keep_all mode, original key is removed when mapped
+		_, hasOriginal := outputData["HASURA_GRAPHQL_ADMIN_SECRET"]
+		assert.False(t, hasOriginal)
+	})
+
+	t.Run("input file not found returns error", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		outputPath := filepath.Join(tmpDir, "output.json")
+
+		config := map[string]interface{}{
+			"type":       "file_json",
+			"input_path": "/nonexistent/input.json",
+			"path":       outputPath,
+			"refresh":    60,
+		}
+
+		provider, err := CreateFileJsonProvider(config, logger)
+		require.NoError(t, err)
+
+		err = provider.Refresh()
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
## Summary

- Adds a new `file_json` provider type that reads secrets from a local JSON file (e.g., a K8s Secret mounted as a volume) and writes transformed output to another file
- Reuses the existing `transform` module for key_mappings, supporting both `keep_all` and `transformed_only` modes
- Enables customers using Sealed Secrets or plain K8s Secrets to use the same env-loader pattern without external vault infrastructure (AWS SM, Azure KV, HashiCorp Vault)

## How it works

1. Customer creates a K8s Secret with a `secrets.json` key containing all secret values as JSON
2. The Secret is mounted as a read-only volume at a configurable `input_path`
3. The `file_json` provider reads the mounted JSON, applies key_mappings (same transform config as other providers), and writes to the output `path`
4. The env-loader reads the mapped JSON and exports env vars — same as existing flow

## Config example

```yaml
my_service:
  type: file_json
  input_path: /source-secrets/secrets.json
  path: /secrets/my-service.json
  refresh: 60
  transform:
    mode: transformed_only
    key_mappings:
      - from: HASURA_GRAPHQL_ADMIN_SECRET
        to: ADMIN_SECRET
      - from: DB_PASSWORD
        to: POSTGRES_PASSWORD
```

## Test plan

- [x] Unit tests for constructor validation (missing fields, conflicting template+transform)
- [x] Unit tests for Refresh with no transform (passthrough)
- [x] Unit tests for Refresh with `transformed_only` mode
- [x] Unit tests for Refresh with `keep_all` mode
- [x] Unit test for missing input file error handling
- [ ] Integration test with real K8s deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)