### PR TITLE
Scrub template secret logs and guard file_json same-path configs

### DIFF
--- a/provider/file_json/file_provider.go
+++ b/provider/file_json/file_provider.go
@@ -3,6 +3,7 @@ package file_json
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -44,6 +45,10 @@ func CreateFileJsonProvider(config map[string]interface{}, logger zerolog.Logger
 	if !ok {
 		logger.Error().Msg("file_json: 'path' must be a string")
 		return FileJsonProvider{}, fmt.Errorf("config not valid")
+	}
+	if err := validateDistinctPaths(inputPath, filePath); err != nil {
+		logger.Err(err).Msg("file_json: invalid path configuration")
+		return FileJsonProvider{}, err
 	}
 
 	refreshIntervalI, found := config["refresh"]
@@ -174,4 +179,46 @@ func (provider FileJsonProvider) writeFile(secretString string) error {
 		return err
 	}
 	return nil
+}
+
+func validateDistinctPaths(inputPath, filePath string) error {
+	resolvedInputPath, err := resolvePathForComparison(inputPath)
+	if err != nil {
+		return fmt.Errorf("config not valid: unable to resolve 'input_path': %w", err)
+	}
+
+	resolvedFilePath, err := resolvePathForComparison(filePath)
+	if err != nil {
+		return fmt.Errorf("config not valid: unable to resolve 'path': %w", err)
+	}
+
+	if resolvedInputPath == resolvedFilePath {
+		return fmt.Errorf("config not valid: 'input_path' and 'path' must refer to different files")
+	}
+
+	return nil
+}
+
+func resolvePathForComparison(path string) (string, error) {
+	cleanedPath := filepath.Clean(path)
+	resolvedPath, err := filepath.EvalSymlinks(cleanedPath)
+	if err == nil {
+		return resolvedPath, nil
+	}
+
+	if !os.IsNotExist(err) {
+		return "", err
+	}
+
+	parentPath := filepath.Dir(cleanedPath)
+	resolvedParentPath, parentErr := filepath.EvalSymlinks(parentPath)
+	if parentErr == nil {
+		return filepath.Join(resolvedParentPath, filepath.Base(cleanedPath)), nil
+	}
+
+	if os.IsNotExist(parentErr) {
+		return cleanedPath, nil
+	}
+
+	return "", parentErr
 }

--- a/provider/file_json/file_provider_test.go
+++ b/provider/file_json/file_provider_test.go
@@ -82,6 +82,48 @@ func TestCreateFileJsonProvider(t *testing.T) {
 		_, err := CreateFileJsonProvider(config, logger)
 		assert.Error(t, err)
 	})
+
+	t.Run("rejects same file after path cleaning", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		inputPath := filepath.Join(tmpDir, "secrets.json")
+
+		err := os.WriteFile(inputPath, []byte(`{"token":"value"}`), 0o644)
+		require.NoError(t, err)
+
+		config := map[string]interface{}{
+			"type":       "file_json",
+			"input_path": filepath.Join(tmpDir, ".", "secrets.json"),
+			"path":       filepath.Join(tmpDir, "nested", "..", "secrets.json"),
+			"refresh":    60,
+		}
+
+		_, err = CreateFileJsonProvider(config, logger)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "'input_path' and 'path' must refer to different files")
+	})
+
+	t.Run("rejects same file through symlink resolution", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		inputPath := filepath.Join(tmpDir, "secrets.json")
+		symlinkPath := filepath.Join(tmpDir, "secrets-link.json")
+
+		err := os.WriteFile(inputPath, []byte(`{"token":"value"}`), 0o644)
+		require.NoError(t, err)
+		if err := os.Symlink(inputPath, symlinkPath); err != nil {
+			t.Skipf("unable to create symlink on this platform: %v", err)
+		}
+
+		config := map[string]interface{}{
+			"type":       "file_json",
+			"input_path": symlinkPath,
+			"path":       inputPath,
+			"refresh":    60,
+		}
+
+		_, err = CreateFileJsonProvider(config, logger)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "'input_path' and 'path' must refer to different files")
+	})
 }
 
 func TestFileJsonProviderRefresh(t *testing.T) {

--- a/template/template.go
+++ b/template/template.go
@@ -2,8 +2,8 @@ package template
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
-	"reflect"
 	"regexp"
 	"strings"
 
@@ -32,31 +32,85 @@ func (t Template) Substitute(with string) string {
 	return result
 }
 
-func jsonTemplate(jsonTemplate, substituteWith string, logger zerolog.Logger) (res string, canContinue bool) {
-	jsonPath := strings.Split(jsonTemplate, ".")
+func jsonTemplate(templateKey, substituteWith string, logger zerolog.Logger) (res string, canContinue bool) {
+	jsonPath := strings.Split(templateKey, ".")
 	if len(jsonPath) < 2 {
 		return substituteWith, true
 	}
 	jsonParsed := make(map[string]interface{})
 	err := json.Unmarshal([]byte(substituteWith), &jsonParsed)
 	if err != nil {
-		logger.Err(err).Msg("Unable to parse secret as a JSON")
-		logger.Debug().Err(err).Msgf("Unable to parse secret as a JSON: %s", substituteWith)
+		logJSONTemplateParseError(logger, templateKey, substituteWith, err)
 		return "", false
 	}
 	jsonKey := strings.TrimSpace(jsonPath[1])
 	val, ok := jsonParsed[jsonKey]
 	if !ok {
-		logger.Error().Msgf("Key %s not found in secret", jsonKey)
-		logger.Debug().Msgf("Key %s not found in secret %s", jsonKey, substituteWith)
+		logger.Error().
+			Str("template_key", templateKey).
+			Msg("Template key not found in secret JSON")
 		return "", true
 	}
-	if reflect.ValueOf(val).Kind() == reflect.Map {
-		logger.Error().Msgf("Nested JSON is not supported in secrets")
-		logger.Debug().Msgf("Nested JSON is not supported, secret: %s", substituteWith)
+	if _, isMap := val.(map[string]interface{}); isMap {
+		logger.Error().
+			Str("template_key", templateKey).
+			Msg("Nested JSON lookups are not supported in secrets")
 		return "", true
 	}
 	valS := fmt.Sprintf("%v", val)
 	valS = strings.TrimSpace(valS)
 	return valS, true
+}
+
+func logJSONTemplateParseError(logger zerolog.Logger, templateKey, rawSecret string, err error) {
+	event := logger.Error().
+		Err(err).
+		Str("template_key", templateKey)
+
+	if offset, line, column, ok := jsonErrorPosition(rawSecret, err); ok {
+		event = event.Int64("offset", offset).Int("line", line).Int("column", column)
+	}
+
+	event.Msg("Unable to parse secret as JSON for template lookup")
+}
+
+func jsonErrorPosition(rawSecret string, err error) (offset int64, line int, column int, ok bool) {
+	var syntaxErr *json.SyntaxError
+	if errors.As(err, &syntaxErr) {
+		line, column = offsetToLineColumn(rawSecret, syntaxErr.Offset)
+		return syntaxErr.Offset, line, column, true
+	}
+
+	var typeErr *json.UnmarshalTypeError
+	if errors.As(err, &typeErr) {
+		line, column = offsetToLineColumn(rawSecret, typeErr.Offset)
+		return typeErr.Offset, line, column, true
+	}
+
+	return 0, 0, 0, false
+}
+
+func offsetToLineColumn(rawSecret string, offset int64) (line int, column int) {
+	if offset < 1 {
+		return 1, 1
+	}
+
+	line = 1
+	column = 1
+	bytes := []byte(rawSecret)
+	limit := int(offset - 1)
+	if limit > len(bytes) {
+		limit = len(bytes)
+	}
+
+	for i := 0; i < limit; i++ {
+		if bytes[i] == '\n' {
+			line++
+			column = 1
+			continue
+		}
+		column++
+	}
+
+	return line, column
 }

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -1,6 +1,7 @@
 package template
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -97,4 +98,74 @@ func TestTemplate_GetKeysFromTemplates(t *testing.T) {
 			t.Errorf("Test case - %s: Expected '%s' but got '%s'", testCase.name, testCase.expected, actual)
 		}
 	}
+}
+
+func TestTemplateDoesNotLeakSecretContentsInLogs(t *testing.T) {
+	t.Run("malformed json reports position without payload", func(t *testing.T) {
+		var logs bytes.Buffer
+		logger := zerolog.New(&logs).Level(zerolog.DebugLevel)
+		template := Template{Templ: "Bearer ##secret1.token##", Logger: logger}
+
+		actual := template.Substitute("{\n  \"token\": \"super-secret\",\n  \"broken\": [1,}\n")
+		if strings.TrimSpace(actual) != "Bearer" {
+			t.Fatalf("expected substitution to stop after parse failure, got %q", actual)
+		}
+
+		logOutput := logs.String()
+		if strings.Contains(logOutput, "super-secret") {
+			t.Fatalf("log output leaked secret contents: %s", logOutput)
+		}
+		if !strings.Contains(logOutput, "\"template_key\":\"secret1.token\"") {
+			t.Fatalf("expected template key in log output, got %s", logOutput)
+		}
+		if !strings.Contains(logOutput, "\"line\":") || !strings.Contains(logOutput, "\"column\":") {
+			t.Fatalf("expected line/column info in log output, got %s", logOutput)
+		}
+	})
+
+	t.Run("lookup failures report key path without payload", func(t *testing.T) {
+		tests := []struct {
+			name           string
+			template       string
+			secret         string
+			expectedLogMsg string
+			expectedKey    string
+		}{
+			{
+				name:           "missing key",
+				template:       "Bearer ##secret1.missing##",
+				secret:         `{"token":"super-secret"}`,
+				expectedLogMsg: "Template key not found in secret JSON",
+				expectedKey:    "secret1.missing",
+			},
+			{
+				name:           "nested object",
+				template:       "Bearer ##secret1.key.inner##",
+				secret:         `{"key":{"inner":"super-secret"}}`,
+				expectedLogMsg: "Nested JSON lookups are not supported in secrets",
+				expectedKey:    "secret1.key.inner",
+			},
+		}
+
+		for _, testCase := range tests {
+			t.Run(testCase.name, func(t *testing.T) {
+				var logs bytes.Buffer
+				logger := zerolog.New(&logs).Level(zerolog.DebugLevel)
+				template := Template{Templ: testCase.template, Logger: logger}
+
+				_ = template.Substitute(testCase.secret)
+
+				logOutput := logs.String()
+				if strings.Contains(logOutput, "super-secret") {
+					t.Fatalf("log output leaked secret contents: %s", logOutput)
+				}
+				if !strings.Contains(logOutput, testCase.expectedLogMsg) {
+					t.Fatalf("expected log message %q, got %s", testCase.expectedLogMsg, logOutput)
+				}
+				if !strings.Contains(logOutput, "\"template_key\":\""+testCase.expectedKey+"\"") {
+					t.Fatalf("expected template key %q in log output, got %s", testCase.expectedKey, logOutput)
+				}
+			})
+		}
+	})
 }


### PR DESCRIPTION
## Summary

- scrubs raw secret payloads from the shared template helper logs and reports only `template_key` plus JSON parse position metadata (`offset`, `line`, `column`)
- adds regression coverage to ensure malformed JSON, missing-key, and nested-object template failures never leak secret contents to logs
- rejects `file_json` configs where `input_path` and `path` resolve to the same file, including cleaned-path and symlink aliases, before any truncation or write happens
- adds constructor tests for the same-path misconfiguration cases

## Context

- Stacks on top of #38
- Fixes the HIGH secret-log-leak review finding in the shared `template` helper
- Fixes the MEDIUM same-path destructive-config review finding in `provider/file_json`

## Validation

- `go build ./...`
- `go test ./template/... ./provider/file_json/...`

## Notes

- Pre-existing unrelated failures in `transform`, `server`, and `provider/azure_key_vault` are unchanged by this PR
